### PR TITLE
Added `/api/healthz` to install routes.

### DIFF
--- a/routers/install/routes.go
+++ b/routers/install/routes.go
@@ -16,6 +16,7 @@ import (
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/modules/web/middleware"
 	"code.gitea.io/gitea/routers/common"
+	"code.gitea.io/gitea/routers/web/healthcheck"
 	"code.gitea.io/gitea/services/forms"
 
 	"gitea.com/go-chi/session"
@@ -106,6 +107,7 @@ func Routes() *web.Route {
 	r.Use(Init)
 	r.Get("/", Install)
 	r.Post("/", web.Bind(forms.InstallForm{}), SubmitInstall)
+	r.Get("/api/healthz", healthcheck.CheckInstall)
 
 	r.NotFound(web.Wrap(installNotFound))
 	return r

--- a/routers/web/healthcheck/check.go
+++ b/routers/web/healthcheck/check.go
@@ -50,8 +50,8 @@ type checks map[string][]componentStatus
 // response is the data returned by the health endpoint, which will be marshaled to JSON format
 type response struct {
 	Status      status `json:"status"`
-	Description string `json:"description"` // a human-friendly description of the service
-	Checks      checks `json:"checks"`      // The Checks Object
+	Description string `json:"description"`      // a human-friendly description of the service
+	Checks      checks `json:"checks,omitempty"` // The Checks Object, should be omitted on installation route
 }
 
 // componentStatus presents one status of a single check object
@@ -80,6 +80,19 @@ func Check(w http.ResponseWriter, r *http.Request) {
 			rsp.Status = fail
 			break
 		}
+	}
+
+	data, _ := json.MarshalIndent(rsp, "", "  ")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(rsp.Status.ToHTTPStatus())
+	_, _ = w.Write(data)
+}
+
+// CheckInstall always return pass. Should only be used in Install routes
+func CheckInstall(w http.ResponseWriter, r *http.Request) {
+	rsp := response{
+		Status:      pass,
+		Description: "Gitea: Installation stage",
 	}
 
 	data, _ := json.MarshalIndent(rsp, "", "  ")


### PR DESCRIPTION
This was needed for using /api/healthz endpoint in Docker healthchecks,
otherwise, Docker would never become healthy if using healthz endpoint
and users would not be able to complete the installation of Gitea.